### PR TITLE
Fixed getFreeSlot()

### DIFF
--- a/src/main/java/seedu/address/model/Schedule.java
+++ b/src/main/java/seedu/address/model/Schedule.java
@@ -23,7 +23,6 @@ public class Schedule implements ReadOnlySchedule {
 
     private final SortedEventList events;
     private final SortedBlockedSlotList blockedSlots;
-    private Date today = null;
 
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
@@ -199,49 +198,104 @@ public class Schedule implements ReadOnlySchedule {
      * Goes through both sortedEventList and sortedBlockedEventList to find free time slots
      * between events and blocked slots.
      *
-     * @param date starting date
+     * @param today starting date
      * @return ArrayList of FreeSlot between date to last event/blocked slot
      */
-    public ArrayList<FreeSlot> getFreeSlots(Date date) {
-        today = date;
+    public ArrayList<FreeSlot> getFreeSlots(Date today) {
         ArrayList<Overlappable> allOverlappables = merge();
         ArrayList<FreeSlot> freeSlots = new ArrayList<>();
         if (allOverlappables.isEmpty()) {
             return freeSlots;
         }
 
-        addEmptyDates(freeSlots, allOverlappables.get(0));
+        addEmptyDates(freeSlots, today, allOverlappables.get(0).getDate());
 
+        if (allOverlappables.size() == 1) {
+            Overlappable e = allOverlappables.get(0);
+            if (!e.getDate().date.isBefore(today.date)) {
+                TimeSlot t = e.getTimeSlot();
+                addToList(freeSlots, e.getDate(), "0000", t.startTimeToString());
+                addToList(freeSlots, e.getDate(), t.endTimeToString(), "2359");
+            }
+            return freeSlots;
+        }
+
+        boolean addedFirstFreeSlot = false;
         for (int i = 1; i < allOverlappables.size(); i++) {
             Overlappable prev = allOverlappables.get(i - 1);
             Overlappable curr = allOverlappables.get(i);
-            String prevEndTime = prev.getTimeSlot().endTimeToString();
-            String currStartTime = curr.getTimeSlot().startTimeToString();
 
-            if (prev.getDate().equals(curr.getDate()) && !prevEndTime.equals(currStartTime)) {
-                freeSlots.add(new FreeSlot(prev.getDate(), new TimeSlot(prevEndTime, currStartTime)));
-            } else {
-                if (!prevEndTime.equals("2359")) {
-                    freeSlots.add(new FreeSlot(prev.getDate(), new TimeSlot(prevEndTime, "2359")));
-                }
-
-                addEmptyDates(freeSlots, curr);
-
-                if (!currStartTime.equals("0000")) {
-                    freeSlots.add(new FreeSlot(curr.getDate(), new TimeSlot("0000", currStartTime)));
-                }
+            // ignore past events and blocked slots when generating free slots
+            if (prev.getDate().date.isBefore(today.date)) {
+                continue;
             }
+            // add free slot from 0000 to start of first event/blocked slot
+            if (!addedFirstFreeSlot) {
+                addedFirstFreeSlot = true;
+                String prevStartTime = prev.getTimeSlot().startTimeToString();
+                addToList(freeSlots, prev.getDate(), "0000", prevStartTime);
+            }
+            // add free slot between prev and curr
+            addFreeSlotBetween(freeSlots, prev, curr);
+        }
+        // add free slot between last event/blocked slot to 2359
+        Overlappable last = allOverlappables.get(allOverlappables.size() - 1);
+        if (!last.getDate().date.isBefore(today.date)) {
+            String lastEndTime = last.getTimeSlot().endTimeToString();
+            addToList(freeSlots, last.getDate(), lastEndTime, "2359");
         }
         return freeSlots;
     }
 
-
-    private void addEmptyDates(ArrayList<FreeSlot> freeSlots, Overlappable next) {
-        while (today.compareTo(next.getDate()) < 0) {
-            freeSlots.add(new FreeSlot(today, new TimeSlot("0000", "2359")));
-            today = new Date(today.date.plusDays(1));
+    /**
+     * Creates a freeSlot on date d and timeslot between start and end.
+     * Adds freeSlot to list of freeSlots.
+     * Ignores if start and end are the same.
+     *
+     * @param freeSlots list of freeSlots
+     * @param d date of freeSlot
+     * @param start start time of freeSlot
+     * @param end end time of freeSlots
+     */
+    private void addToList(ArrayList<FreeSlot> freeSlots, Date d, String start, String end) {
+        if (!start.equals(end)) {
+            freeSlots.add(new FreeSlot(d, new TimeSlot(start, end)));
         }
-        today = new Date(today.date.plusDays(1));
+    }
+
+    /**
+     * Adds freeSlots for timeslot between first and second events/blocked slots.
+     *
+     * @param freeSlots list of freeSlots
+     * @param first first event/blocked slot
+     * @param second second event/blocked slot
+     */
+    public void addFreeSlotBetween(ArrayList<FreeSlot> freeSlots, Overlappable first, Overlappable second) {
+        String firstEndTime = first.getTimeSlot().endTimeToString();
+        String secondStartTime = second.getTimeSlot().startTimeToString();
+
+        if (first.getDate().equals(second.getDate())) {
+            addToList(freeSlots, first.getDate(), firstEndTime, secondStartTime);
+        } else {
+            addToList(freeSlots, first.getDate(), firstEndTime, "2359");
+            addEmptyDates(freeSlots, new Date(first.getDate().date.plusDays(1)), second.getDate());
+            addToList(freeSlots, second.getDate(), "0000", secondStartTime);
+        }
+    }
+
+    /**
+     * Adds freeSlots for whole days between start (inclusive) and end (exclusive) dates.
+     *  @param freeSlots list of freeSlots
+     * @param start start date
+     * @param end end date
+     */
+    public void addEmptyDates(ArrayList<FreeSlot> freeSlots, Date start, Date end) {
+        if (!start.date.isBefore(end.date)) {
+            return;
+        } else {
+            freeSlots.add(new FreeSlot(start, new TimeSlot("0000", "2359")));
+            addEmptyDates(freeSlots, new Date(start.date.plusDays(1)), end);
+        }
     }
 
 }

--- a/src/test/java/seedu/address/model/ScheduleTest.java
+++ b/src/test/java/seedu/address/model/ScheduleTest.java
@@ -1,8 +1,12 @@
 package seedu.address.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalEvents.ALICE;
+import static seedu.address.testutil.TypicalEvents.BENSON;
+import static seedu.address.testutil.TypicalEvents.getTypicalBlockedSlots;
 import static seedu.address.testutil.TypicalEvents.getTypicalEvents;
 import static seedu.address.testutil.TypicalEvents.getTypicalSchedule;
 
@@ -45,20 +49,99 @@ public class ScheduleTest {
     }
 
     @Test
-    public void emptySchedule_getFreeSlot_emptyList() {
+    public void addEmptyDates() {
+        ArrayList<FreeSlot> sameStartAndEnd = new ArrayList<>();
+        schedule.addEmptyDates(sameStartAndEnd, ALICE.getDate(), ALICE.getDate());
+        assertTrue(sameStartAndEnd.isEmpty());
+
+        ArrayList<FreeSlot> startBeforeEnd = new ArrayList<>();
+        schedule.addEmptyDates(startBeforeEnd, ALICE.getDate(), BENSON.getDate());
+        assertTrue(startBeforeEnd.size() == 1);
+
+        ArrayList<FreeSlot> startAfterEnd = new ArrayList<>();
+        schedule.addEmptyDates(startAfterEnd, BENSON.getDate(), ALICE.getDate());
+        assertTrue(startAfterEnd.isEmpty());
+    }
+
+    @Test
+    public void getFreeSlot_emptySchedule_emptyList() {
         Schedule empty = new Schedule();
         assertEquals(new ArrayList<>(), empty.getFreeSlots(new Date("2020-01-01")));
     }
 
     @Test
-    public void nonEmptySchedule_getFreeSlot_nonEmptyList() {
+    public void getFreeSlot_scheduleWithSingleEvent() {
+        Schedule schedule = new Schedule();
+        schedule.addEvent(BENSON);
+        ArrayList<FreeSlot> freeSlotsSameDay = schedule.getFreeSlots(new Date("2020-01-02"));
+        assertTrue(freeSlotsSameDay.size() == 2);
+
+        ArrayList<FreeSlot> freeSlotsDayBefore = schedule.getFreeSlots(new Date("2020-01-01"));
+        assertTrue(freeSlotsDayBefore.size() == 3);
+
+        ArrayList<FreeSlot> freeSlotsDayAfter = schedule.getFreeSlots(new Date("2020-01-03"));
+        assertTrue(freeSlotsDayAfter.size() == 0);
+
+    }
+
+    @Test
+    public void getFreeSlot_nonEmptySchedule_nonEmptyList() {
         Schedule schedule = getTypicalSchedule();
+        ArrayList<FreeSlot> freeSlots = schedule.getFreeSlots(new Date("2020-01-01"));
+        assertFalse(freeSlots.isEmpty());
+        for (FreeSlot f: freeSlots) {
+            for (Event e: getTypicalEvents()) {
+                assertFalse(f.isOverlappingWith(e));
+            }
+            for (BlockedSlot b: getTypicalBlockedSlots()) {
+                assertFalse(f.isOverlappingWith(b));
+            }
+        }
+    }
+
+    @Test
+    public void getFreeSlot_backToBackEvents_nonEmptyList() {
+        Schedule schedule = new Schedule();
+        for (BlockedSlot b: getTypicalBlockedSlots()) {
+            schedule.addBlockedSlot(b);
+        }
+        ArrayList<FreeSlot> freeSlots = schedule.getFreeSlots(new Date("2020-01-01"));
+        for (FreeSlot f: freeSlots) {
+            for (BlockedSlot b: getTypicalBlockedSlots()) {
+                assertFalse(f.isOverlappingWith(b));
+            }
+        }
+    }
+
+    @Test
+    public void getFreeSlot_noBackToBackEvents_nonEmptyList() {
+        Schedule schedule = new Schedule();
+        for (Event e: getTypicalEvents()) {
+            schedule.addEvent(e);
+        }
         ArrayList<FreeSlot> freeSlots = schedule.getFreeSlots(new Date("2020-01-01"));
         for (FreeSlot f: freeSlots) {
             for (Event e: getTypicalEvents()) {
-                assertTrue(!f.isOverlappingWith(e));
+                assertFalse(f.isOverlappingWith(e));
             }
         }
+    }
+
+    @Test
+    public void getFreeSlot_eventsBeforeStartDate_ignorePastEvents() {
+        Schedule scheduleWithSomePastEvents = getTypicalSchedule();
+        ArrayList<FreeSlot> freeSlots1 = scheduleWithSomePastEvents.getFreeSlots(new Date("2020-01-03"));
+        Schedule scheduleWithoutSomePastEvents = getTypicalSchedule();
+        scheduleWithoutSomePastEvents.removeEvent(ALICE);
+        scheduleWithoutSomePastEvents.removeEvent(BENSON);
+        ArrayList<FreeSlot> freeSlots2 = scheduleWithoutSomePastEvents.getFreeSlots(new Date("2020-01-03"));
+        assertEquals(freeSlots2, freeSlots1);
+
+        Schedule scheduleWithAllPastEvents = getTypicalSchedule();
+        ArrayList<FreeSlot> freeSlots3 = scheduleWithAllPastEvents.getFreeSlots(new Date("2020-10-10"));
+        Schedule scheduleWithoutAllPastEvents = new Schedule();
+        ArrayList<FreeSlot> freeSlots4 = scheduleWithoutAllPastEvents.getFreeSlots(new Date("2020-10-10"));
+        assertEquals(freeSlots4, freeSlots3);
     }
 
     /**


### PR DESCRIPTION
 Scenario | Expected Behavior
-----| -----
Empty Schedule | empty list of freeSlots
Schedule with events before today | ignores past events
Schedule with one event | freeSlots before and after event
Schedule with multiple events | freeSlots from 0000 of today until 2359 of last day with events
Schedule with empty days | freeSlots from 0000-2359 for empty days

Assumptions:
- Day starts at 0000 and ends at 2359
- Events do not span multiple days
- FreeSlots are non empty i.e. freeSlot cannot start and end at the same time
