### PR TITLE
Fix timeslot formatting error

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -92,7 +92,8 @@ public class ParserUtil {
         String trimmedTimeSlot = timeSlot.trim();
         String[] startTimeAndEndTime = trimmedTimeSlot.split("-"); // Index 0: startTime; Index 1: endTime;
         try {
-            if (!TimeSlot.isValidTimeSlot(startTimeAndEndTime[0], startTimeAndEndTime[1])) {
+            if (!TimeSlot.isValidTimeSlot(startTimeAndEndTime[0], startTimeAndEndTime[1])
+                    || startTimeAndEndTime.length != 2) {
                 throw new ParseException(TimeSlot.MESSAGE_CONSTRAINTS);
             }
             return new TimeSlot(startTimeAndEndTime[0], startTimeAndEndTime[1]);


### PR DESCRIPTION
Fix error where the command `edit 1 t/0000-1300-0000-1400` will go through. Now an error will be thrown instead.